### PR TITLE
Integrate with vanilla minecraft chat

### DIFF
--- a/src/main/java/io/github/darkkronicle/advancedchathud/HudChatMessage.java
+++ b/src/main/java/io/github/darkkronicle/advancedchathud/HudChatMessage.java
@@ -26,30 +26,25 @@ public class HudChatMessage {
 
     public HudChatMessage(ChatMessage message) {
         this(message, new ArrayList<>());
-        ArrayList<AbstractChatTab> added = new ArrayList<>();
+
         boolean forward = true;
         if (AdvancedChatHud.MAIN_CHAT_TAB.getCustomChatTabs().size() > 0) {
             for (CustomChatTab tab : AdvancedChatHud.MAIN_CHAT_TAB.getCustomChatTabs()) {
                 if (!tab.shouldAdd(message.getOriginalText())) {
                     continue;
                 }
-                if (added.contains(tab)) {
+                if (tabs.contains(tab)) {
                     continue;
                 }
-                added.add(tab);
+                tabs.add(tab);
                 if (!tab.isForward()) {
                     forward = false;
                     break;
                 }
             }
         }
-        if (forward) {
-            added.add(AdvancedChatHud.MAIN_CHAT_TAB);
-        }
-        for (AbstractChatTab tab : added) {
-            tab.addNewUnread();
-        }
-        setTabs(added);
+        if (forward) tabs.add(AdvancedChatHud.MAIN_CHAT_TAB);
+        for (AbstractChatTab tab : tabs) tab.addNewUnread();
     }
 
     public HudChatMessage(ChatMessage message, List<AbstractChatTab> tabs) {

--- a/src/main/java/io/github/darkkronicle/advancedchathud/HudInitHandler.java
+++ b/src/main/java/io/github/darkkronicle/advancedchathud/HudInitHandler.java
@@ -19,6 +19,7 @@ import io.github.darkkronicle.advancedchathud.config.GuiTabManager;
 import io.github.darkkronicle.advancedchathud.config.HudConfigStorage;
 import io.github.darkkronicle.advancedchathud.gui.HudSection;
 import io.github.darkkronicle.advancedchathud.gui.WindowManager;
+import io.github.darkkronicle.advancedchathud.itf.IChatHud;
 import io.github.darkkronicle.advancedchathud.tabs.MainChatTab;
 import java.util.List;
 import net.fabricmc.api.EnvType;
@@ -51,7 +52,7 @@ public class HudInitHandler implements IInitializationHandler {
                                 return new GuiTabManager(buttons);
                             }
                         });
-        AdvancedChatHud.MAIN_CHAT_TAB = new MainChatTab();
+        IChatHud.getInstance().setTab(AdvancedChatHud.MAIN_CHAT_TAB = new MainChatTab());
 
         // Register on the clear
         ChatScreenSectionHolder.getInstance().addSectionSupplier(HudSection::new);

--- a/src/main/java/io/github/darkkronicle/advancedchathud/gui/HudSection.java
+++ b/src/main/java/io/github/darkkronicle/advancedchathud/gui/HudSection.java
@@ -40,12 +40,13 @@ public class HudSection extends AdvancedChatScreenSection {
     public void initGui() {
         int x = 2;
         int space = 2;
-        int y = MinecraftClient.getInstance().getWindow().getScaledHeight() - 15 - 11;
+        int y = MinecraftClient.getInstance().getWindow().getScaledHeight() - 31;
         for (AbstractChatTab tab : AdvancedChatHud.MAIN_CHAT_TAB.getAllChatTabs()) {
             TabButton button = TabButton.fromTab(tab, x, y);
             getScreen().addButton(button, null);
             x += button.getWidth() + space;
         }
+        getScreen().addButton(new NewWindowButton(x, y), null);
     }
 
     @Override
@@ -76,7 +77,6 @@ public class HudSection extends AdvancedChatScreenSection {
         if (!Screen.hasShiftDown()) {
             amount *= 7.0D;
         }
-        WindowManager.getInstance().scroll(amount, mouseX, mouseY);
-        return true;
+        return WindowManager.getInstance().scroll(amount, mouseX, mouseY);
     }
 }

--- a/src/main/java/io/github/darkkronicle/advancedchathud/gui/NewWindowButton.java
+++ b/src/main/java/io/github/darkkronicle/advancedchathud/gui/NewWindowButton.java
@@ -1,0 +1,56 @@
+package io.github.darkkronicle.advancedchathud.gui;
+
+import fi.dy.masa.malilib.render.RenderUtils;
+import io.github.darkkronicle.advancedchatcore.gui.CleanButton;
+import io.github.darkkronicle.advancedchatcore.util.ColorUtil;
+import io.github.darkkronicle.advancedchathud.itf.IChatHud;
+import net.minecraft.client.sound.PositionedSoundInstance;
+import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.sound.SoundEvents;
+
+public class NewWindowButton extends CleanButton {
+
+    private static final int PADDING = 3;
+    private static final int SIZE = PADDING + 9 + PADDING;
+
+    public NewWindowButton(int x, int y) {
+        super(x, y, SIZE, SIZE, null, null);
+    }
+
+    @Override
+    public void render(int mouseX, int mouseY, boolean unused, MatrixStack matrixStack) {
+        int relMX = mouseX - x;
+        int relMY = mouseY - y;
+        hovered = relMX >= 0 && relMX <= width && relMY >= 0 && relMY <= height;
+
+        ColorUtil.SimpleColor plusBack = ColorUtil.BLACK.withAlpha(100);
+        boolean plusHovered = hovered && relMX >= width - height;
+        if (plusHovered) {
+            plusBack = ColorUtil.WHITE.withAlpha(plusBack.alpha());
+        }
+
+        RenderUtils.drawRect(x, y, width, height, plusBack.color());
+
+        RenderUtils.drawVerticalLine(
+                x + (int) Math.floor((float) width / 2),
+                y + PADDING,
+                height - (PADDING * 2),
+                ColorUtil.WHITE.color());
+        RenderUtils.drawHorizontalLine(
+                x + PADDING,
+                y + (int) Math.floor((float) height / 2),
+                width - (PADDING * 2),
+                ColorUtil.WHITE.color());
+
+    }
+
+    @Override
+    protected boolean onMouseClickedImpl(int mouseX, int mouseY, int mouseButton) {
+        this.mc
+                .getSoundManager()
+                .play(PositionedSoundInstance.master(SoundEvents.UI_BUTTON_CLICK, 1.0F));
+        WindowManager.getInstance().onTabAddButton(IChatHud.getInstance().getTab());
+        return true;
+    }
+
+}

--- a/src/main/java/io/github/darkkronicle/advancedchathud/gui/WindowManager.java
+++ b/src/main/java/io/github/darkkronicle/advancedchathud/gui/WindowManager.java
@@ -13,6 +13,7 @@ import fi.dy.masa.malilib.interfaces.IRenderer;
 import io.github.darkkronicle.advancedchatcore.chat.AdvancedChatScreen;
 import io.github.darkkronicle.advancedchathud.AdvancedChatHud;
 import io.github.darkkronicle.advancedchathud.HudChatMessage;
+import io.github.darkkronicle.advancedchathud.itf.IChatHud;
 import io.github.darkkronicle.advancedchathud.tabs.AbstractChatTab;
 import java.util.LinkedList;
 import net.fabricmc.api.EnvType;
@@ -47,12 +48,7 @@ public class WindowManager implements IRenderer {
 
     public void loadFromJson(JsonArray array) {
         reset();
-        if (array == null || array.size() == 0) {
-            ChatWindow base = new ChatWindow(AdvancedChatHud.MAIN_CHAT_TAB);
-            base.setSelected(true);
-            windows.add(base);
-            return;
-        }
+        if (array == null || array.size() == 0) return;
         ChatWindow.ChatWindowSerializer serializer = new ChatWindow.ChatWindowSerializer();
         for (JsonElement e : array) {
             if (!e.isJsonObject()) {
@@ -102,12 +98,14 @@ public class WindowManager implements IRenderer {
         }
     }
 
-    public void scroll(double amount, double mouseX, double mouseY) {
+    public boolean scroll(double amount, double mouseX, double mouseY) {
         for (ChatWindow w : windows) {
-            if (w.isSelected() || w.isMouseOver(mouseX, mouseY)) {
+            if (w.isSelected() && w.isMouseOver(mouseX, mouseY)) {
                 w.scroll(amount);
+                return true;
             }
         }
+        return false;
     }
 
     public Style getText(double mouseX, double mouseY) {
@@ -202,6 +200,7 @@ public class WindowManager implements IRenderer {
     }
 
     public void onTabButton(AbstractChatTab tab) {
+        IChatHud.getInstance().setTab(tab);
         for (ChatWindow w : windows) {
             if (w.isSelected()) {
                 w.setTab(tab);
@@ -237,12 +236,14 @@ public class WindowManager implements IRenderer {
     }
 
     public void onNewMessage(HudChatMessage message) {
+        IChatHud.getInstance().addMessage(message);
         for (ChatWindow w : windows) {
             w.addMessage(message);
         }
     }
 
     public void clear() {
+        IChatHud.getInstance().clear(false);
         for (ChatWindow w : windows) {
             w.clearLines();
         }

--- a/src/main/java/io/github/darkkronicle/advancedchathud/itf/IChatHud.java
+++ b/src/main/java/io/github/darkkronicle/advancedchathud/itf/IChatHud.java
@@ -1,0 +1,21 @@
+package io.github.darkkronicle.advancedchathud.itf;
+
+import io.github.darkkronicle.advancedchathud.HudChatMessage;
+import io.github.darkkronicle.advancedchathud.tabs.AbstractChatTab;
+import net.minecraft.client.MinecraftClient;
+
+public interface IChatHud {
+
+    AbstractChatTab getTab();
+
+    void setTab(AbstractChatTab tab);
+
+    void addMessage(HudChatMessage message);
+
+    void clear(boolean clearHistory);
+
+
+    static IChatHud getInstance() {
+        return (IChatHud) MinecraftClient.getInstance().inGameHud.getChatHud();
+    }
+}

--- a/src/main/java/io/github/darkkronicle/advancedchathud/mixin/MixinChatHud.java
+++ b/src/main/java/io/github/darkkronicle/advancedchathud/mixin/MixinChatHud.java
@@ -7,29 +7,99 @@
  */
 package io.github.darkkronicle.advancedchathud.mixin;
 
-import io.github.darkkronicle.advancedchathud.gui.WindowManager;
+import io.github.darkkronicle.advancedchatcore.chat.ChatMessage;
+import io.github.darkkronicle.advancedchathud.HudChatMessage;
+import io.github.darkkronicle.advancedchathud.HudChatMessageHolder;
+import io.github.darkkronicle.advancedchathud.config.HudConfigStorage;
+import io.github.darkkronicle.advancedchathud.itf.IChatHud;
+import io.github.darkkronicle.advancedchathud.tabs.AbstractChatTab;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
+import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.hud.ChatHud;
-import net.minecraft.client.util.math.MatrixStack;
-import net.minecraft.text.Style;
+import net.minecraft.client.gui.hud.ChatHudLine;
+import net.minecraft.client.util.ChatMessages;
+import net.minecraft.text.OrderedText;
+import net.minecraft.text.Text;
+import net.minecraft.util.math.MathHelper;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.spongepowered.asm.mixin.Shadow;
+
+import java.util.Iterator;
+import java.util.List;
 
 @Mixin(value = ChatHud.class, priority = 1050)
 @Environment(EnvType.CLIENT)
-public class MixinChatHud {
+public abstract class MixinChatHud implements IChatHud {
 
-    @Inject(at = @At("HEAD"), method = "getText", cancellable = true)
-    private void getTextAt(double X, double Y, CallbackInfoReturnable<Style> ci) {
-        ci.setReturnValue(WindowManager.getInstance().getText(X, Y));
+    @Shadow @Final private MinecraftClient client;
+    @Shadow @Final private List<ChatHudLine<Text>> messages;
+    @Shadow @Final private List<ChatHudLine<OrderedText>> visibleMessages;
+
+    @Shadow private int scrolledLines;
+    @Shadow private boolean hasUnreadNewMessages;
+
+    private AbstractChatTab tab;
+
+
+    @Shadow public abstract void reset();
+
+    @Shadow public abstract int getWidth();
+
+    @Shadow public abstract double getChatScale();
+
+    @Shadow protected abstract boolean isChatFocused();
+
+    @Shadow public abstract void scroll(double amount);
+
+    @Shadow public abstract void clear(boolean clearHistory);
+
+    @Override
+    public void addMessage(HudChatMessage hudMsg) {
+        if (tab == null || !hudMsg.getTabs().contains(tab)) return;
+        tab.resetUnread();
+
+        int width = MathHelper.floor((double)this.getWidth() / this.getChatScale());
+
+        ChatMessage msg = hudMsg.getMessage();
+
+        List<OrderedText> list = ChatMessages.breakRenderedChatMessageLines(msg.getDisplayText(), width, this.client.textRenderer);
+
+        OrderedText orderedText;
+        for (Iterator<OrderedText> text = list.iterator(); text.hasNext();
+             this.visibleMessages.add(0, new ChatHudLine<>(msg.getCreationTick(), orderedText, msg.getId()))) {
+            orderedText = text.next();
+            if (this.isChatFocused() && this.scrolledLines > 0) {
+                this.hasUnreadNewMessages = true;
+                this.scroll(1.0D);
+            }
+        }
+
+        while (this.visibleMessages.size() > HudConfigStorage.General.STORED_LINES.config.getIntegerValue()) {
+            this.visibleMessages.remove(this.visibleMessages.size() - 1);
+        }
+
+        this.messages.add(0, new ChatHudLine<>(msg.getCreationTick(), msg.getDisplayText(), msg.getId()));
+        while (this.messages.size() > HudConfigStorage.General.STORED_LINES.config.getIntegerValue()) {
+            this.messages.remove(this.messages.size() - 1);
+        }
     }
 
-    @Inject(at = @At("HEAD"), method = "render", cancellable = true)
-    private void render(MatrixStack stack, int delta, CallbackInfo ci) {
-        ci.cancel();
+    public AbstractChatTab getTab() {
+        return tab;
     }
+
+    public void setTab(AbstractChatTab tab) {
+        this.tab = tab;
+        this.messages.clear();
+        this.visibleMessages.clear();
+
+        List<HudChatMessage> messages = HudChatMessageHolder.getInstance().getMessages();
+        for (int i = messages.size() - 1; i >= 0; i--) {
+            addMessage(messages.get(i));
+        }
+        this.reset();
+    }
+
 }

--- a/src/main/java/io/github/darkkronicle/advancedchathud/util/TextUtil.java
+++ b/src/main/java/io/github/darkkronicle/advancedchathud/util/TextUtil.java
@@ -1,0 +1,17 @@
+package io.github.darkkronicle.advancedchathud.util;
+
+public class TextUtil {
+
+    private static final char[] SUPERSCRIPTS = new char[]{
+            '\u2070', '\u00B9', '\u00B2', '\u00B3', '\u2074', '\u2075', '\u2076', '\u2077', '\u2078', '\u2079'
+    };
+
+    public static String toSuperscript(int num) {
+        StringBuilder sb = new StringBuilder();
+        do {
+            sb.append(SUPERSCRIPTS[num % 10]);
+        } while ((num /= 10) > 0);
+        return sb.reverse().toString();
+    }
+
+}


### PR DESCRIPTION
Let the vanilla minecraft chat work as it usually does (instead of straight hiding it by blocking the render function) and integrate with it by adding/removing messages when selecting tabs

This allows using the mod without needing to use any of the custom windows, retaining both all the positioning/sizing functionalities of the vanilla minecraft chat and the power of tabs and filtering messages